### PR TITLE
ESTDEV-1456

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -127,8 +127,6 @@ module Sigh
       cert = certificate_to_use
       bundle_id = Sigh.config[:app_identifier]
       name = Sigh.config[:provisioning_name] || [bundle_id, profile_type.pretty_type].join(' ')
-      devlist = []
-      devlist << Spaceship.device.find_by_udid(Sigh.config[:add])
 
       unless Sigh.config[:skip_fetch_profiles]
         if Spaceship.provisioning_profile.all.find { |p| p.name == name }
@@ -137,6 +135,9 @@ module Sigh
         end
       end
       if Sigh.config[:add]
+        devlist = []
+        devlist << Spaceship.device.find_by_udid(Sigh.config[:add])
+
         UI.important "Creating new provisioning profile for '#{Sigh.config[:app_identifier]}' with name '#{name}' and UDID '#{Sigh.config[:add]}'"
         profile = profile_type.create!(name: name,
                                   bundle_id: bundle_id,

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -127,6 +127,8 @@ module Sigh
       cert = certificate_to_use
       bundle_id = Sigh.config[:app_identifier]
       name = Sigh.config[:provisioning_name] || [bundle_id, profile_type.pretty_type].join(' ')
+      devlist = []
+      devlist << Spaceship.device.find_by_udid(Sigh.config[:add])
 
       unless Sigh.config[:skip_fetch_profiles]
         if Spaceship.provisioning_profile.all.find { |p| p.name == name }
@@ -134,11 +136,19 @@ module Sigh
           name += " #{Time.now.to_i}"
         end
       end
-
-      UI.important "Creating new provisioning profile for '#{Sigh.config[:app_identifier]}' with name '#{name}'"
-      profile = profile_type.create!(name: name,
-                                bundle_id: bundle_id,
-                              certificate: cert)
+      if Sigh.config[:add]
+        UI.important "Creating new provisioning profile for '#{Sigh.config[:app_identifier]}' with name '#{name}' and UDID '#{Sigh.config[:add]}'"
+        profile = profile_type.create!(name: name,
+                                  bundle_id: bundle_id,
+                                certificate: cert,
+                                 devices: devlist)
+ 
+      else
+        UI.important "Creating new provisioning profile for '#{Sigh.config[:app_identifier]}' with name '#{name}'"
+        profile = profile_type.create!(name: name,
+                                  bundle_id: bundle_id,
+                                certificate: cert)
+      end
       profile
     end
 


### PR DESCRIPTION
This small code change allows new profiles to be created using only the UDID provided. (Basically, this patch makes sigh honour the --add option when creating a profile, instead of just when updating it).